### PR TITLE
Modify QSS idealized nml files, damp_opt=1 allows testing use_theta_m=1

### DIFF
--- a/Namelists/weekly/em_quarter_ss/namelist.input.02
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.02
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss/namelist.input.02NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.02NE
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss/namelist.input.03
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.03
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss/namelist.input.03NE
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.03NE
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss/namelist.input.08
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.08
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss/namelist.input.09
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.09
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss/namelist.input.10
+++ b/Namelists/weekly/em_quarter_ss/namelist.input.10
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.02
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.02
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.03
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.03
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.08
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.08
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.09
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.09
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_quarter_ss8/namelist.input.10
+++ b/Namelists/weekly/em_quarter_ss8/namelist.input.10
@@ -68,7 +68,7 @@
  /
 
  &dynamics
- use_theta_m                         = 0
+ use_theta_m                         = 1
  rk_ord                              = 3,
  diff_opt                            = 2,
  km_opt                              = 2,

--- a/Namelists/weekly/em_real/MPI/namelist.input.02
+++ b/Namelists/weekly/em_real/MPI/namelist.input.02
@@ -92,6 +92,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.02GR
+++ b/Namelists/weekly/em_real/MPI/namelist.input.02GR
@@ -92,6 +92,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.02ST
+++ b/Namelists/weekly/em_real/MPI/namelist.input.02ST
@@ -92,6 +92,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.07
+++ b/Namelists/weekly/em_real/MPI/namelist.input.07
@@ -88,6 +88,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.07NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.07NE
@@ -93,6 +93,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.07VN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.07VN
@@ -92,6 +92,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.12
+++ b/Namelists/weekly/em_real/MPI/namelist.input.12
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.12GR
+++ b/Namelists/weekly/em_real/MPI/namelist.input.12GR
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.14
+++ b/Namelists/weekly/em_real/MPI/namelist.input.14
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.14VN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.14VN
@@ -89,6 +89,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.15
+++ b/Namelists/weekly/em_real/MPI/namelist.input.15
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.15AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.15AD
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.16
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.16BN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16BN
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.16DF
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16DF
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.16VN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.16VN
@@ -88,6 +88,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.17
+++ b/Namelists/weekly/em_real/MPI/namelist.input.17
@@ -92,6 +92,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.17AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.17AD
@@ -92,6 +92,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.17VN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.17VN
@@ -96,6 +96,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.18
+++ b/Namelists/weekly/em_real/MPI/namelist.input.18
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.18BN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.18BN
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.18VN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.18VN
@@ -88,6 +88,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.19
+++ b/Namelists/weekly/em_real/MPI/namelist.input.19
@@ -89,6 +89,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.20
+++ b/Namelists/weekly/em_real/MPI/namelist.input.20
@@ -88,6 +88,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.20NE
+++ b/Namelists/weekly/em_real/MPI/namelist.input.20NE
@@ -93,6 +93,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.29
+++ b/Namelists/weekly/em_real/MPI/namelist.input.29
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.29QT
+++ b/Namelists/weekly/em_real/MPI/namelist.input.29QT
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.32
+++ b/Namelists/weekly/em_real/MPI/namelist.input.32
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.33
+++ b/Namelists/weekly/em_real/MPI/namelist.input.33
@@ -85,6 +85,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.34
+++ b/Namelists/weekly/em_real/MPI/namelist.input.34
@@ -85,6 +85,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.35
+++ b/Namelists/weekly/em_real/MPI/namelist.input.35
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.36
+++ b/Namelists/weekly/em_real/MPI/namelist.input.36
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.36GR
+++ b/Namelists/weekly/em_real/MPI/namelist.input.36GR
@@ -90,6 +90,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.38
+++ b/Namelists/weekly/em_real/MPI/namelist.input.38
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.38AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.38AD
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.38VN
+++ b/Namelists/weekly/em_real/MPI/namelist.input.38VN
@@ -88,6 +88,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,      1,      1,
  km_opt                              = 4,      4,      4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.39
+++ b/Namelists/weekly/em_real/MPI/namelist.input.39
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.39AD
+++ b/Namelists/weekly/em_real/MPI/namelist.input.39AD
@@ -84,6 +84,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.41
+++ b/Namelists/weekly/em_real/MPI/namelist.input.41
@@ -92,6 +92,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/Namelists/weekly/em_real/MPI/namelist.input.71
+++ b/Namelists/weekly/em_real/MPI/namelist.input.71
@@ -86,6 +86,7 @@
  /
 
  &dynamics
+ use_theta_m                         = 1,
  w_damping                           = 0,
  diff_opt                            = 1,
  km_opt                              = 4,

--- a/bsub_this_to_run_all_compilers.csh
+++ b/bsub_this_to_run_all_compilers.csh
@@ -5,7 +5,7 @@
 #BSUB -n 16                # number of total tasks
 #BSUB -o reggie.out        # output filename
 #BSUB -e reggie.err        # error filename
-#BSUB -J WTF_v03.04        # job name
+#BSUB -J WTF_v03.05        # job name
 #BSUB -q caldera           # queue: premium, regular, economy
 #BSUB -W 6:00              # wallclock time hh:mm
 #BSUB -P P64000400


### PR DESCRIPTION
We have never tested use_theta_m=1 (moist potential temperature) in the regression test.  

When activated, there were a couple of known failures due to the choice of damp_opt (use_theta_m=1 does not work with damp_opt=2).  With this consistent setting, now all of the possible quarter super cell cases that are able to test use_theta_m=1 do now test use_theta_m=1.  Similarly,  all of the possible em_real cases that have damp_opt=1, now have use_theta_m=1.

The regression tests pass for the idealized super cell case with the use_theta_m flag for:
- serial, OpenMP, MPI  
- single domain, nest  
- real4, real8

The regression tests pass for em_real with use_theta_m=1 for:
- serial, OpenMP, MPI
- single domain, nest, vertical nest

This should be the upgrade to v03.05.  The file bsub* has been updated with the new name.